### PR TITLE
src: Corregimos el paginador para que haga wrap en resolucion desktop…

### DIFF
--- a/templates/list.html
+++ b/templates/list.html
@@ -80,12 +80,14 @@
         </article>
         <!-- start pagination nav buttons -->
         <div class="row">
-          <div class="column is-5">
+          <div class="column is-12">
             Showing {{ list_help_paginated }}
           </div>
-          <div class="column is-5">
+        </div>
+        <div class="row">
+          <div class="column is-12">
             {% if list_help_paginated.has_other_pages %}
-            <ul class="pagination">
+            <ul class="pagination" style="flex-wrap: wrap;">
               <!-- previous (<<) nav button -->
               {% if list_help_paginated.has_previous %}
               <li><a href="?page={{ list_help_paginated.previous_page_number }}"


### PR DESCRIPTION
… tambien, sino solo se veia hasta la pagina 13

- En resolución desktop se perdía el paginador, porque no hacia wrap de los demás botones como si lo hacia en resoluciones menores a 785px.