### PR TITLE
datalist: fix issue with the browser "back" button

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -63,6 +63,14 @@
         .cities-dropdown-wrapper {
             margin-bottom: 1em;
         }
+
+        .cities-dropdown input::-webkit-calendar-picker-indicator {
+              opacity: 0;
+        }
+
+        .cities-dropdown .select {
+            width: 100%;
+        }
     </style>
     <script src="https://cdn.jsdelivr.net/npm/@vizuaalog/bulmajs@0.10.3/dist/file.js" integrity="sha256-9BDCQ1iKLp8eEXxQD6U8StZ4V2On9KFEHDeHeXLZ/aE=" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/@vizuaalog/bulmajs@0.10.3/dist/modal.js" integrity="sha256-HDcVnTQ5+DdyigrR4Xge4rxqguBi19XI7vNDhTDr+hs=" crossorigin="anonymous"></script>

--- a/templates/list.html
+++ b/templates/list.html
@@ -39,24 +39,26 @@
               <div class="cities-dropdown" role="menu">
                 <div class="field is-horizontal">
                   <div class="field-label is-normal">
-                    <label class="label">Ciudades</label>
+                    <label class="label" for="cities">Ciudades</label>
                   </div>
                   <div class="field-body">
                     <div class="field">
-                      <p class="control">
-                        <input name="cities" class="input" list="list_cities" placeholder="Seleccionar ciudad...">
-                      </p>
+                      <div class="control">
+                        <div class="select">
+                          <input name="cities" class="input" list="list_cities" placeholder="Seleccionar ciudad..." autocomplete="off">
+                        </div>
+                      </div>
                     </div>
                   </div>
                 </div>
                 <datalist id="list_cities">
-                    <select size=10>
-                      {% for city, code in list_cities %}
-                        <option data-value="{{code}}">
-                          {{city}}
-                        </option>
-                      {% endfor %}
-                    </select>
+                      <select size=10>
+                        {% for city, code in list_cities %}
+                          <option data-value="{{code}}">
+                            {{city}}
+                          </option>
+                        {% endfor %}
+                      </select>
                   </datalist>
               </div>
             </div>
@@ -161,6 +163,7 @@
 
           /* input.onchange is triggered when the user selects something from the datalist */
           input = document.querySelector('input');
+        
           input.addEventListener('change', function() {
             var selectedValue = input.value;
             var selectedIndex;
@@ -176,6 +179,11 @@
             }
             var selectedOption = options[selectedIndex];
             location.assign('/pedidos_ciudad/' + selectedOption.getAttribute('data-value'));
+          });
+
+          /* when user selects an option from the datalist, write it to text field */
+          select.addEventListener('change', function() {
+            input.value = options[this.selectedIndex].value;
           });
         }
 


### PR DESCRIPTION
It seems that when autocomplete is on, we can hit enter with an
empty text field, and we will face a 404 in the request info page.
I tested this update, and it seems to solve the issue. However,
I was not able to reproduce the exact error that we've seen in production.

I also added the "select" CSS class to the dropdown to show the arrow
in the input field.


It looks like this now:

![image](https://user-images.githubusercontent.com/732626/78962931-c1642a80-7ac3-11ea-9af2-6aff803183f8.png)
