### PR TITLE
API feature search with selectable fields #95

### DIFF
--- a/conf/urls.py
+++ b/conf/urls.py
@@ -15,7 +15,6 @@ from core import views as core_views
 router = routers.DefaultRouter()
 router.register(r'helprequests', core_views.HelpRequestViewSet)
 router.register(r'helprequestsgeo', core_views.HelpRequestGeoViewSet)
-router.register(r'helprequestssearch', core_views.HelpRequestSearchViewSet)
 
 urlpatterns = [
     path('admin/', admin.site.urls),

--- a/core/serializers.py
+++ b/core/serializers.py
@@ -1,5 +1,5 @@
 from rest_framework import serializers
-from rest_framework_gis.serializers import GeoFeatureModelSerializer, GeoModelSerializer, ModelSerializer
+from rest_framework_gis.serializers import GeoFeatureModelSerializer, GeoModelSerializer
 
 from .models import HelpRequest
 
@@ -16,8 +16,3 @@ class HelpRequestGeoJSONSerializer(GeoFeatureModelSerializer):
         model = HelpRequest
         fields = ['pk', 'title', 'message', 'name']
         geo_field = 'location'
-
-class HelpRequestSearchSerializer(ModelSerializer):
-	class Meta:
-		model = HelpRequest
-		fields = ['id', 'title', 'message', 'name', 'phone', 'address', 'city', 'location', 'picture', 'active', 'added']

--- a/core/serializers.py
+++ b/core/serializers.py
@@ -14,5 +14,5 @@ class HelpRequestSerializer(GeoModelSerializer):
 class HelpRequestGeoJSONSerializer(GeoFeatureModelSerializer):
     class Meta:
         model = HelpRequest
-        fields = ['pk', 'title', 'message', 'name']
+        fields = ['pk', 'title', 'message', 'name','active', 'added']
         geo_field = 'location'

--- a/core/views.py
+++ b/core/views.py
@@ -26,7 +26,7 @@ class DynamicSearchFilter(filters.SearchFilter):
         return request.GET.getlist('search_fields', [])
 
 class HelpRequestViewSet(viewsets.ReadOnlyModelViewSet):
-    queryset = HelpRequest.objects.filter(active=True)
+    queryset = HelpRequest.objects.filter(active=True).order_by('-id')
     serializer_class = HelpRequestSerializer
     filter_backends = [InBBoxFilter, DjangoFilterBackend, DynamicSearchFilter,]
     search_fields = ['title', 'phone',]
@@ -36,7 +36,7 @@ class HelpRequestViewSet(viewsets.ReadOnlyModelViewSet):
 
 
 class HelpRequestGeoViewSet(viewsets.ReadOnlyModelViewSet):
-    queryset = HelpRequest.objects.filter(active=True)
+    queryset = HelpRequest.objects.filter(active=True).order_by('-pk')
     pagination_class = None
     serializer_class = HelpRequestGeoJSONSerializer
     bbox_filter_field = 'location'

--- a/core/views.py
+++ b/core/views.py
@@ -15,14 +15,20 @@ from django_filters.rest_framework import DjangoFilterBackend
 
 from .forms import HelpRequestForm
 from .models import HelpRequest, HelpRequestOwner, FrequentAskedQuestion, HelpRequestQuerySet
-from .serializers import HelpRequestSerializer, HelpRequestGeoJSONSerializer, HelpRequestSearchSerializer
+from .serializers import HelpRequestSerializer, HelpRequestGeoJSONSerializer
 from .utils import text_to_image, image_to_base64
 
+"""
+    API endpoints that allows search queries on HelpRequest
+"""
+class DynamicSearchFilter(filters.SearchFilter):
+    def get_search_fields(self, view, request):
+        return request.GET.getlist('search_fields', [])
 
 class HelpRequestViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = HelpRequest.objects.filter(active=True)
     serializer_class = HelpRequestSerializer
-    filter_backends = [InBBoxFilter, DjangoFilterBackend, filters.SearchFilter]
+    filter_backends = [InBBoxFilter, DjangoFilterBackend, DynamicSearchFilter,]
     search_fields = ['title', 'phone',]
     filterset_fields = ['city']
     bbox_filter_field = 'location'
@@ -34,21 +40,8 @@ class HelpRequestGeoViewSet(viewsets.ReadOnlyModelViewSet):
     pagination_class = None
     serializer_class = HelpRequestGeoJSONSerializer
     bbox_filter_field = 'location'
-    filter_backends = (InBBoxFilter, )
+    filter_backends = (InBBoxFilter, DynamicSearchFilter,)
     bbox_filter_include_overlapping = True
-
-"""
-    API endpoint that allows search queries on the HelpRequest
-"""
-class DynamicSearchFilter(filters.SearchFilter):
-    def get_search_fields(self, view, request):
-        return request.GET.getlist('search_fields', [])
-
-class HelpRequestSearchViewSet(viewsets.ReadOnlyModelViewSet):
-    filter_backends = (DynamicSearchFilter,)
-    queryset = HelpRequest.objects.all()
-    pagination_class = None
-    serializer_class = HelpRequestSearchSerializer
 
 
 def home(request):


### PR DESCRIPTION
Modification on endpoints

`api/v1/helprequests`

The endpoint accepts now two search parameters;

- **search** that is the string that will be searched

- **search_fields** which defines the fields on the HelpRequest that are going to be searched on

`api/v1/helprequestsgeo`

The endpoint accepts now two search parameters;

- **search** that is the string that will be searched

- **search_fields** which defines the fields on the HelpRequest that are going to be searched on\

- **active** and **added** are now also included

