### PR TITLE
templates: Enable map clustering by default

### DIFF
--- a/templates/list.html
+++ b/templates/list.html
@@ -150,16 +150,14 @@
         //We check if the browser support local Storage caching
         //in case does not, we disable the switch
         var switchElement = document.getElementById('switchNormal');
+        switchElement.checked = true;
 
         if (typeof (Storage) === "undefined") {
           switchElement.disabled = true;
         } else {
-          switchElement.checked = false;
           var isGroupMarksActive = JSON.parse(localStorage.getItem("group_markers_setting"));
-          if (isGroupMarksActive != null) {
-            if (isGroupMarksActive) {
-              switchElement.checked = true;
-            }
+          if (isGroupMarksActive !== null && !isGroupMarksActive) {
+            switchElement.checked = false;
           }
         }
       }
@@ -196,7 +194,7 @@
 
                 //We check the switch status
                 var isGroupMarksActive = JSON.parse(localStorage.getItem("group_markers_setting"));
-                if (!isGroupMarksActive) {
+                if (isGroupMarksActive !== null && !isGroupMarksActive) {
                   clusters = loadMarkers(map, data);//load markers without clustering
                 } else {
                   clusters = loadMarkersAndGroup(map, data);


### PR DESCRIPTION
The app behaves way too laggy in highly populated areas therefore, it might be worth considering a smarter way to decide whether or not to use map clustering. e.g. marks.length > threshold ? enabled : disabled;

Until then, it could be beneficial to the user to have its default to "enabled".