### PR TITLE
Upgrade pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ git clone git@github.com:melizeche/ayudapy.git
 cd ayudapy
 python3 -m venv env
 source env/bin/activate
+pip install --upgrade pip
 pip install -r requirements.txt
 cp conf/.env.example conf/.env # you should edit this file with your configuration
 ./manage.py migrate


### PR DESCRIPTION
Actualizar pip preventivamente. Puede ser que el ambiente ambiente donde se crea el venv sea anciano y con una versión muy vieja de pip.

Signed-off-by: Diego Schulz <dschulz@gmail.com>