### PR TITLE
Fix phishing chance vulnerabilities on external links and other

### DIFF
--- a/templates/footer/contact_us.html
+++ b/templates/footer/contact_us.html
@@ -33,7 +33,7 @@
         </div>
 
           <div class="tile is-child buttons">
-          <a href="https://www.twitter.com/ayudapyorg" target="_blank">
+          <a href="https://www.twitter.com/ayudapyorg" target="_blank" rel="noopener noreferrer">
             <button class="button is-medium">
               <span class="icon">
                 <i class="fab fa-twitter has-text-info"></i>
@@ -41,7 +41,7 @@
               <!-- <span>@ayuda_py</span> -->
             </button>
           </a>
-          <a href="https://instagram.com/ayudapyorg" target="_blank">
+          <a href="https://instagram.com/ayudapyorg" target="_blank" rel="noopener noreferrer">
             <button class="button is-medium">
               <span class="icon">
                 <i class="fab fa-instagram has-text-danger"></i>
@@ -49,7 +49,7 @@
               <!-- <span>@ayuda.py</span> -->
             </button>
           </a>
-          <a href="https://www.facebook.com/ayudapyorg/" target="_blank">
+          <a href="https://www.facebook.com/ayudapyorg/" target="_blank" rel="noopener noreferrer">
             <button class="button is-medium">
               <span class="icon">
                 <i class="fab fa-facebook has-text-link"></i>
@@ -57,7 +57,7 @@
               <!-- <span>@ayudapy</span> -->
             </button>
           </a>
-          <a href="https://www.youtube.com/channel/UCtRcDRTKA2uQCzfvlPNvbNQ" target="_blank">
+          <a href="https://www.youtube.com/channel/UCtRcDRTKA2uQCzfvlPNvbNQ" target="_blank" rel="noopener noreferrer">
             <button class="button is-medium">
               <span class="icon">
                 <i class="fab fa-youtube has-text-danger"></i>

--- a/templates/footer/footer.html
+++ b/templates/footer/footer.html
@@ -35,7 +35,7 @@
       <p class="column is-size-7 has-text-centered has-text-right-desktop is-family-monospace">
         Desarrollado por <a href="https://melizeche.com">Marcelo Elizeche</a>
         <br> Código fuente libre bajo licencia <a href="https://opensource.org/licenses/GPL-3.0">GPLv3</a>
-        <br><a href="https://github.com/melizeche/ayudapy" target="_blank">Revisá el código <span class="icon"><i
+        <br><a href="https://github.com/melizeche/ayudapy" target="_blank" rel="noopener noreferrer">Revisá el código <span class="icon"><i
               class="fab fa-github" title="logo Github"></i></span></a>
       </p>
       <!-- </div> -->

--- a/templates/home.html
+++ b/templates/home.html
@@ -33,7 +33,6 @@
                 </a>
             </div>
             <div class="column is-3">
-{#                <a target="_blank" href="https://forms.gle/qgfZ28Vd1xUv9s9n9">#}
                 <a href="/voluntario/legal">
                     <article class="tile is-child notification has-text-centered" style="background-color: #f95d82; color: white;">
                         <p class="title is-4">¡Quiero ser voluntario!</p>
@@ -44,7 +43,6 @@
         </div>
         {% else %}
         <div class="columns is-centered">
-    {#        {% if perms.org.add_donationcenter %}#}
             <div class="column is-4">
                 <a href="/dar">
                     <article class="tile is-child notification has-text-centered"


### PR DESCRIPTION
Add `rel="noopener noreferrer"` to external links with `target="_blank" `to prevent the original page from being modified by the opened link.