### PR TITLE
Implement daily stats service

### DIFF
--- a/conf/api_urls.py
+++ b/conf/api_urls.py
@@ -17,6 +17,6 @@ router.register(r'donationcentersgeo', org_api.DonationCenterGeoViewSet)
 
 urlpatterns = [
     path(f"{PREFIX}/", include(router.urls)),
-    path(f"{PREFIX}/stats", core_api.StatsView)
+    path(f"{PREFIX}/stats-summary", core_api.StatsSummaryView)
 ]
 

--- a/conf/api_urls.py
+++ b/conf/api_urls.py
@@ -17,6 +17,7 @@ router.register(r'donationcentersgeo', org_api.DonationCenterGeoViewSet)
 
 urlpatterns = [
     path(f"{PREFIX}/", include(router.urls)),
-    path(f"{PREFIX}/stats-summary", core_api.StatsSummaryView)
+    path(f"{PREFIX}/stats-summary", core_api.StatsSummaryView),
+    path(f"{PREFIX}/stats-daily", core_api.StatsDailyView)
 ]
 

--- a/core/api.py
+++ b/core/api.py
@@ -87,7 +87,12 @@ def StatsDailyView(request):
                                                    .annotate(total=Count('date')) \
                                                    .order_by('date') \
                                                    .values('date', 'total') 
-    total_resolved = HelpRequest.objects.filter(resolved=True, added__gte=date_from, added__lte=date_to).annotate(date = TruncDate('added')).values('date').annotate(total=Count('date')).order_by('date').values('date', 'total')
+    total_resolved = HelpRequest.objects.filter(resolved=True, added__gte=date_from, added__lte=date_to) \
+                                        .annotate(date = TruncDate('added')) \
+                                        .values('date') \
+                                        .annotate(total=Count('date')) \
+                                        .order_by('date') \
+                                        .values('date', 'total')
     stats = dict(
         total_active = list(total_active),
         total_active_unique_phone = list(total_active_unique_phone),

--- a/core/api.py
+++ b/core/api.py
@@ -1,10 +1,13 @@
 from datetime import date, timedelta
 from django.http import JsonResponse
 from django_filters.rest_framework import DjangoFilterBackend
+from django.db.models import Count
+from django.db.models.functions import TruncDate
 from rest_framework import filters
 from rest_framework import viewsets, status, mixins
 from rest_framework.response import Response
 from rest_framework_gis.filters import InBBoxFilter
+
 
 from core.middleware import USER_TYPE_DEVICE
 from core.models import HelpRequest, Device, User
@@ -25,10 +28,10 @@ class HelpRequestViewSet(viewsets.ModelViewSet):
     queryset = HelpRequest.objects.filter(active=True, resolved=False).order_by('-id')
     serializer_class = HelpRequestSerializer
     filter_backends = [InBBoxFilter, DjangoFilterBackend, DynamicSearchFilter, ]
-    search_fields = ['title', 'phone',]
+    search_fields = ['title', 'phone', ]
     filterset_fields = {
-            'added': ['gte', 'lte', 'date'],
-            'city': ['exact'],
+        'added': ['gte', 'lte', 'date'],
+        'city': ['exact'],
     }
     bbox_filter_field = 'location'
     bbox_filter_include_overlapping = True
@@ -61,6 +64,38 @@ def StatsSummaryView(request):
     return JsonResponse(stats, )
 
 
+def StatsDailyView(request):
+    try:
+        date_from = request.GET["date_from"]
+        date_to = request.GET["date_to"]
+    except:
+        error_msg = "You should specify query parameters date_from and date_to"
+        return JsonResponse({"msg": error_msg}, status=status.HTTP_400_BAD_REQUEST)
+
+
+    total_active = HelpRequest.objects.filter(active=True, resolved = False, added__gte=date_from, added__lte=date_to) \
+                                      .annotate(date = TruncDate('added')) \
+                                      .values('date') \
+                                      .annotate(total=Count('date')) \
+                                      .order_by('date') \
+                                      .values('date', 'total')
+    distinct_requests = HelpRequest.objects.filter(active=True, resolved=False, added__gte=date_from, added__lte=date_to) \
+                                           .distinct('phone').values('id')
+    total_active_unique_phone = HelpRequest.objects.filter(id__in=distinct_requests) \
+                                                   .annotate(date = TruncDate('added')) \
+                                                   .values('date') \
+                                                   .annotate(total=Count('date')) \
+                                                   .order_by('date') \
+                                                   .values('date', 'total') 
+    total_resolved = HelpRequest.objects.filter(resolved=True, added__gte=date_from, added__lte=date_to).annotate(date = TruncDate('added')).values('date').annotate(total=Count('date')).order_by('date').values('date', 'total')
+    stats = dict(
+        total_active = list(total_active),
+        total_active_unique_phone = list(total_active_unique_phone),
+        total_resolved = list(total_resolved)
+    )
+    return JsonResponse(stats, )
+
+
 """
 API to create/update/remove devices.
 Will be used by the Mobile Client
@@ -79,6 +114,7 @@ class DeviceViewSet(mixins.RetrieveModelMixin,
     """
     Create a model instance.
     """
+
     def create(self, request, *args, **kwargs):
 
         # create device
@@ -104,5 +140,4 @@ class DeviceViewSet(mixins.RetrieveModelMixin,
             return {'Location': str(data[api_settings.URL_FIELD_NAME])}
         except (TypeError, KeyError):
             return {}
-
 

--- a/core/api.py
+++ b/core/api.py
@@ -49,7 +49,7 @@ class CitiesViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = CitiesSerializer
 
 
-def StatsView(request):
+def StatsSummaryView(request):
     today = date.today()
     stats = dict(
         total_active=HelpRequest.objects.filter(active=True, resolved=False).count(),

--- a/core/views.py
+++ b/core/views.py
@@ -13,7 +13,7 @@ import json
 import datetime
 import base64
 
-from .api import StatsView
+from .api import StatsSummaryView
 from .forms import HelpRequestForm
 from .models import HelpRequest, HelpRequestOwner, FrequentAskedQuestion
 from .utils import text_to_image, image_to_base64
@@ -180,6 +180,6 @@ def list_by_city(request, city):
 
 @login_required
 def stats(request):
-    datos = StatsView(request)
+    datos = StatsSummaryView(request)
     context = {"datos": json.loads(datos.content)}
-    return render(request, "stats/stats_index.html", context)
+    return render(request, "stats/dashboard.html", context)

--- a/templates/stats/dashboard.html
+++ b/templates/stats/dashboard.html
@@ -1,0 +1,68 @@
+{% extends 'base.html'%}
+
+{% block bread %}
+  <nav class="breadcrumb  has-arrow-separator" aria-label="breadcrumbs">
+    <ul>
+      <li>
+        <a href="/">
+          <span class="icon is-small">
+            <i class="fas fa-home" aria-hidden="true"></i>
+          </span>
+          <span>Inicio</span>
+        </a>
+      </li>
+      <li class="is-active"><a href="#" aria-current="page">Estadísticas</a></li>
+      </ul>
+  </nav>
+{% endblock bread %}
+
+{% block content %}
+<div class="is-fullhd">
+    <div class="columns is-multiline">
+        <div class="column">
+            <div class="box notification is-link">
+                <div class="heading">Total Pedidos Activos</div>
+                    <div class="title has-text-centered">{{ datos.total_active }}</div>
+{#                        <div class="level">#}
+{#                            <div class="level-item">#}
+{#                                <div>#}
+{#                                    <div class="heading">Hoy</div>#}
+{#                                    <div class="title is-5">{{ datos.today }}</div>#}
+{#                                </div>#}
+{#                            </div>#}
+{#                            <div class="level-item"><div>#}
+{#                                <div class="heading">Ayer</div>#}
+{#                                    <div class="title is-5">{{ datos.yesterday }}</div>#}
+{#                                </div>#}
+{#                            </div>#}
+{#                        </div>#}
+            </div>
+        </div>
+    <div class="column">
+        <div class="box notification is-warning">
+            <div class="heading">Total Registrados</div>
+            <div class="title has-text-centered">{{ datos.total_active_unique_phone }}</div>
+        </div>
+    </div>
+        <div class="column">
+            <div class="box notification is-info">
+                <div class="heading">Pedidos Atendidos</div>
+                <div class="title has-text-centered">{{ datos.total_resolved }}</div>
+            </div>
+        </div>
+        <div class="column">
+            <div class="box notification is-success">
+                <div class="heading">Total Pedidos de hoy</div>
+                <div class="title has-text-centered">{{ datos.today }}</div>
+            </div>
+        </div>
+        <div class="column">
+            <div class="box notification is-danger">
+                <div class="heading">Total Pedidos de ayer</div>
+                <div class="title has-text-centered">{{ datos.yesterday }}</div>
+            </div>
+        </div>
+    </div>
+</div>
+
+{% endblock %}


### PR DESCRIPTION
I implemented the service that returns daily statistics (as discussed in #240).

The service is `/api/v1/stats-daily?date_from=2020-04-01&date_to=2020-04-15` where the query parameters are required. It returns the following:

![image](https://user-images.githubusercontent.com/732626/81131253-8b766280-8f18-11ea-8e89-b3e5b25d4715.png)

I also renamed the current `/stats` service to `/stats-summary` just for consistency (and renamed the template to `dashboard.html`).
