### PR TITLE
Add default postgis engine

### DIFF
--- a/conf/settings.py
+++ b/conf/settings.py
@@ -92,7 +92,7 @@ WSGI_APPLICATION = 'conf.wsgi.application'
 DATABASES = {
     'default': env.db(),
 }
-
+DATABASES['default']['ENGINE'] = 'django.contrib.gis.db.backends.postgis'
 
 # Password validation
 # https://docs.djangoproject.com/en/2.2/ref/settings/#auth-password-validators


### PR DESCRIPTION
I found this error when migrating 
```
  File "./manage.py", line 21, in <module>
    main()
  File "./manage.py", line 17, in main
    execute_from_command_line(sys.argv)
  File "/home/septian/Workspaces/ayudapy/venv/lib/python3.6/site-packages/django/core/management/__init__.py", line 381, in execute_from_command_line
    utility.execute()
  File "/home/septian/Workspaces/ayudapy/venv/lib/python3.6/site-packages/django/core/management/__init__.py", line 375, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/home/septian/Workspaces/ayudapy/venv/lib/python3.6/site-packages/django/core/management/base.py", line 323, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/home/septian/Workspaces/ayudapy/venv/lib/python3.6/site-packages/django/core/management/base.py", line 364, in execute
    output = self.handle(*args, **options)
  File "/home/septian/Workspaces/ayudapy/venv/lib/python3.6/site-packages/django/core/management/base.py", line 83, in wrapped
    res = handle_func(*args, **kwargs)
  File "/home/septian/Workspaces/ayudapy/venv/lib/python3.6/site-packages/django/core/management/commands/migrate.py", line 234, in handle
    fake_initial=fake_initial,
  File "/home/septian/Workspaces/ayudapy/venv/lib/python3.6/site-packages/django/db/migrations/executor.py", line 117, in migrate
    state = self._migrate_all_forwards(state, plan, full_plan, fake=fake, fake_initial=fake_initial)
  File "/home/septian/Workspaces/ayudapy/venv/lib/python3.6/site-packages/django/db/migrations/executor.py", line 147, in _migrate_all_forwards
    state = self.apply_migration(state, migration, fake=fake, fake_initial=fake_initial)
  File "/home/septian/Workspaces/ayudapy/venv/lib/python3.6/site-packages/django/db/migrations/executor.py", line 245, in apply_migration
    state = migration.apply(state, schema_editor)
  File "/home/septian/Workspaces/ayudapy/venv/lib/python3.6/site-packages/django/db/migrations/migration.py", line 124, in apply
    operation.database_forwards(self.app_label, schema_editor, old_state, project_state)
  File "/home/septian/Workspaces/ayudapy/venv/lib/python3.6/site-packages/django/db/migrations/operations/models.py", line 92, in database_forwards
    schema_editor.create_model(model)
  File "/home/septian/Workspaces/ayudapy/venv/lib/python3.6/site-packages/django/db/backends/base/schema.py", line 257, in create_model
    definition, extra_params = self.column_sql(model, field)
  File "/home/septian/Workspaces/ayudapy/venv/lib/python3.6/site-packages/django/db/backends/base/schema.py", line 150, in column_sql
    db_params = field.db_parameters(connection=self.connection)
  File "/home/septian/Workspaces/ayudapy/venv/lib/python3.6/site-packages/django/db/models/fields/__init__.py", line 696, in db_parameters
    type_string = self.db_type(connection)
  File "/home/septian/Workspaces/ayudapy/venv/lib/python3.6/site-packages/django/contrib/gis/db/models/fields.py", line 105, in db_type
    return connection.ops.geo_db_type(self)
AttributeError: 'DatabaseOperations' object has no attribute 'geo_db_type'
```

It turns out the postgis engine isn't set yet.
Thus I add one on settings