### PR TITLE
merge master into dev

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 django==4.2.21
-Pillow==10.1.0
+Pillow==10.4.0
 psycopg2-binary==2.9.9
 django-leaflet==0.29.0
 black


### PR DESCRIPTION
* Bump djangorestframework from 3.14.0 to 3.15.2

Bumps [djangorestframework](https://github.com/encode/django-rest-framework) from 3.14.0 to 3.15.2.
- [Release notes](https://github.com/encode/django-rest-framework/releases)
- [Commits](https://github.com/encode/django-rest-framework/compare/3.14.0...3.15.2)

---
updated-dependencies:
- dependency-name: djangorestframework dependency-type: direct:production ...



* Bump django from 4.2.18 to 4.2.21

Bumps [django](https://github.com/django/django) from 4.2.18 to 4.2.21.
- [Commits](https://github.com/django/django/compare/4.2.18...4.2.21)

---
updated-dependencies:
- dependency-name: django dependency-version: 4.2.21 dependency-type: direct:production ...



* Update pillow version

---------